### PR TITLE
Updating trigger: oas_take_up_trigger

### DIFF
--- a/trigger/oas_take_up_trigger.json
+++ b/trigger/oas_take_up_trigger.json
@@ -2,7 +2,7 @@
 	"name": "oas_take_up_trigger",
 	"properties": {
 		"annotations": [],
-		"runtimeState": "Started",
+		"runtimeState": "Stopped",
 		"pipelines": [
 			{
 				"pipelineReference": {


### PR DESCRIPTION
Disable trigger for oas take up ingestion pipelines, so the pipeline doesn't trigger during Rosanne's presentation
Will enable trigger once she has presented