### PR TITLE
Updating trigger: oas_take_up_trigger

### DIFF
--- a/trigger/oas_take_up_trigger.json
+++ b/trigger/oas_take_up_trigger.json
@@ -2,7 +2,7 @@
 	"name": "oas_take_up_trigger",
 	"properties": {
 		"annotations": [],
-		"runtimeState": "Stopped",
+		"runtimeState": "Started",
 		"pipelines": [
 			{
 				"pipelineReference": {


### PR DESCRIPTION
Activate Adobe Analytics pipeline trigger so the pipelines can run on schedule every two hours